### PR TITLE
docs: Hermes Agent analysis + M1 Max 64GB local AI memory budget

### DIFF
--- a/research/Hermes/README.md
+++ b/research/Hermes/README.md
@@ -1,0 +1,204 @@
+# Hermes Agent 对 Mycelium Protocol 生态的适用性分析
+
+> 调研日期：2026-05-05
+> 对象：[NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) v0.12.0
+> 目标：评估 Hermes Agent 是否有助于实现 Brood 及 Mycelium Protocol 生态的现有目标和扩展目标
+
+---
+
+## 1. Hermes Agent 是什么
+
+Hermes Agent 是 Nous Research 于 2026 年 2 月发布的开源自改进 AI Agent 框架。MIT License。截至 2026-05，GitHub 133k stars。
+
+**核心定位**：一个**自托管、持久运行、越用越聪明**的 AI Agent——它从经验中自动创建 skill，在使用中自改进 skill，跨 session 保留记忆。
+
+### 关键特性
+
+| 特性 | 描述 |
+|:---|:---|
+| **自学习循环** | 复杂任务（5+ tool calls）后自动创建可复用 skill 文档；使用中自动 patch 过时/不完整的 skill |
+| **持久记忆** | MEMORY.md + USER.md 跨 session 持久化；SQLite + FTS5 全文检索历史；可插拔记忆后端（Honcho/Mem0 等） |
+| **多平台网关** | Telegram / Discord / Slack / WhatsApp / Signal / CLI 统一接入，单进程服务 |
+| **模型无关** | 支持 200+ 模型（OpenRouter/NIM/OpenAI/本地 endpoint），无代码切换 |
+| **MCP 支持** | 原生 MCP client，可连接任意 MCP server 扩展工具能力 |
+| **Skill 生态** | 672 skills（89 内置 + 62 可选 + 521 社区），agentskills.io 开放标准 |
+| **自进化** | DSPy + GEPA 遗传进化搜索优化 skill/prompt/代码（hermes-agent-self-evolution repo） |
+| **部署灵活** | 本地 / Docker / SSH / Serverless（Modal 休眠），一行 curl 安装 |
+| **子 Agent** | 可 spawn 子 agent 实例（默认 3 并发），隔离上下文 |
+| **定时任务** | 自然语言或 cron 表达式调度，可附加 skill 和脚本 |
+| **上下文发现** | 自动识别 `.hermes.md` / `AGENTS.md` / `CLAUDE.md` / `SOUL.md` 等项目文件 |
+
+### 技术架构
+
+```
+AIAgent (orchestration core)
+├── prompt_builder → system prompt 组装（personality + memory + skills + model 指令）
+├── context_compressor → 超长上下文有损压缩
+├── model_tools (61 tools / 52 toolsets) → 工具注册 + 调度 + 并行执行
+├── hermes_state (SQLite + FTS5) → session lineage + 原子写入
+├── plugin system → user/project/pip 三级插件发现
+│   ├── memory providers (Honcho/Mem0/Supermemory...)
+│   └── context engines (可替换压缩策略)
+├── MCP client → 动态工具后端
+├── gateway (20 platform adapters) → 统一消息路由
+└── cron scheduler → 定时任务 + skill 附加
+```
+
+---
+
+## 2. Brood / Mycelium Protocol 当前目标
+
+从 CLAUDE.md、MISSION.md、backlog 任务中提取的核心目标：
+
+| # | 目标 | 当前实现 |
+|---|:---|:---|
+| G1 | **项目管理 + 静态发布** | backlog CLI + export-backlog.js → dist/ |
+| G2 | **生态 AI 上下文发布** | L0/L1/L2 三层 @-include，所有 repo 引用 Brood |
+| G3 | **自动化 Skill 系统** | sync-progress / sync-context-reverse / license-update |
+| G4 | **进度扫描 + 同步** | scan 三大目录 → 分析 commit → 写入任务文件 → build → deploy |
+| G5 | **License 合规** | 七件套模板 + CLA bot |
+| G6 | **跨 repo 协作感知** | ECOSYSTEM_MAP + INTERFACES.md + 依赖关系图 |
+| G7 | **个人 AI Agent（iDoris/Agent24）** | 独立 repo，各自开发中 |
+
+---
+
+## 3. 匹配度分析：Hermes Agent 能帮什么
+
+### ✅ 高匹配（直接增强现有目标）
+
+#### 3.1 替代/增强 Agent24 的个人 Agent 能力（G7）
+
+**当前痛点**：Agent24 是自研框架，功能尚在 35-45% 进度。
+
+**Hermes 方案**：
+- Hermes 的 skill 自创建 + 自改进机制 = Agent24 想做的"自进化 Claude Code Skills 系统"
+- 持久记忆 = Agent24 的 MemPalace 模块目标
+- 多平台网关 = Agent-WeChat-SDK 想做的微信/Signal/Telegram 接入
+- 已有 672 skills 生态 vs Agent24 从零开始
+- **建议**：评估 Agent24 是否可以 pivot 为 Hermes 生态的 Mycelium 定制层，而非从零自研
+
+#### 3.2 定时自动化 sync-progress / sync-context-reverse（G3, G4）
+
+**当前痛点**：三个 skill 只能人工触发，容易忘记跑 → 进度报告过期。
+
+**Hermes 方案**：
+- Hermes 的 cron scheduler 支持自然语言定时（"每天早上 9 点跑 sync-progress"）
+- 可附加 skill + 脚本，天然适合定时扫描 + 同步 + 部署
+- 子 agent spawn = 并行扫描多个 org 目录
+- **具体做法**：将 sync-progress 和 sync-context-reverse 注册为 Hermes skill，配置 cron 每日自动执行
+
+#### 3.3 跨平台生态协作通知（G6）
+
+**当前痛点**：进度更新、接口变更只在 Brood 静态站上可见，团队成员需要手动检查。
+
+**Hermes 方案**：
+- Gateway 接入 Telegram/Discord/Slack → 自动推送进度报告/接口变更通知
+- 团队成员可在 IM 中直接问 Agent："SuperPaymaster 当前进度？"
+- 比静态页面更主动的信息推送
+
+### 🔶 中等匹配（需要适配但有价值）
+
+#### 3.4 增强上下文管理（G2）
+
+**当前做法**：手动维护 L0/L1 文件，@-include 静态引用。
+
+**Hermes 视角**：
+- Hermes 的 context discovery 自动识别 `CLAUDE.md` 等文件——和我们的体系兼容
+- 但 Hermes 用自己的 `.hermes.md` / `SOUL.md` 格式，需要适配
+- **机会**：用 Hermes 插件将 Brood 的 L0/L1 文件注册为 memory provider，让 Hermes Agent 也能感知生态上下文
+- **风险**：两套上下文系统并行可能增加维护负担
+
+#### 3.5 iDoris 个人 AI 底座（G7）
+
+**当前定位**：iDoris = 隐私优先 · Token Free · 边缘计算 · 多端自进化开源 AI 模型
+
+**Hermes 视角**：
+- Hermes 自托管 + 无遥测 + 无云锁定 = 符合 iDoris 的隐私优先理念
+- 但 Hermes 是 Python（88%），iDoris 可能需要更轻量的边缘部署
+- 可作为 iDoris 的"大脑层"，边缘推理层另做
+
+### ⚠️ 低匹配 / 需谨慎
+
+#### 3.6 Blockchain/Web3 集成
+
+- Hermes 本身**没有原生 Web3 能力**
+- 通过 MCP 可连接 GoldRush（链上数据查询），但和 SuperPaymaster/AirAccount 的合约交互无直接关系
+- 我们的 Web3 基础设施（SuperPaymaster/AirAccount/SuperRelay）是 Solidity + Go + TypeScript 技术栈，Hermes 的 Python 生态帮不上底层合约开发
+- **但可以做**：用 Hermes Agent 作为 Web3 操作的自然语言前端（"帮我查 SuperPaymaster 在 Sepolia 上的余额"）
+
+#### 3.7 静态发布系统（G1）
+
+- Hermes 不替代 backlog CLI + export-backlog.js
+- 但可以通过 cron 自动触发 `pnpm run build` + `pnpm run deploy:cf`
+
+---
+
+## 4. 战略建议
+
+### 短期（1-2 周）：试点验证
+
+1. **在 Brood 中部署 Hermes Agent 实例**
+   - 安装到 `~/Dev/auraai/hermes-instance/` 或独立目录
+   - 配置使用 OpenRouter（复用已有 API key）
+   - 让它读取 Brood 的 CLAUDE.md 和 protocol/ 文件作为上下文
+
+2. **将 sync-progress 注册为 Hermes skill**
+   - 测试自动定时执行（每日一次）
+   - 验证能否自动完成 扫描 → 同步 → build → deploy 全流程
+
+3. **开通 Telegram bot 通知**
+   - 进度报告自动推送到团队 Telegram 群
+
+### 中期（1-2 月）：Agent24 整合评估
+
+4. **Agent24 + Hermes 整合调研**
+   - Agent24 当前进度 45%，核心功能（skill system/memory/eval）和 Hermes 高度重叠
+   - 评估：Agent24 转型为 Hermes plugin/skill package vs 继续独立开发
+   - 决策标准：Hermes 的 skill 标准（agentskills.io）能否承载 Agent24 的差异化功能
+
+5. **iDoris 架构对接**
+   - Hermes 作为 iDoris 的"云端大脑"层，边缘设备用轻量推理
+   - 通过 MCP 连接 iDoris 的本地模型能力
+
+### 长期（3+ 月）：生态级 Agent 基础设施
+
+6. **Mycelium + Hermes 深度集成**
+   - 定制 Hermes memory provider：连接 Brood 的 L0/L1 上下文
+   - 定制 Hermes skill package：封装生态所有自动化能力
+   - 每个生态 repo 可配置独立的 Hermes profile（隔离上下文）
+
+---
+
+## 5. 风险与顾虑
+
+| 风险 | 级别 | 缓解措施 |
+|:---|:---:|:---|
+| Hermes 发展方向可能偏离我们需求 | 中 | MIT License，可 fork；先小范围试点 |
+| 两套 skill 系统并行（Claude Code + Hermes）增加复杂度 | 高 | 明确边界：Claude Code = 开发时 AI，Hermes = 运营时自动化 Agent |
+| Python 生态 vs 我们的 TS/Solidity/Go 主技术栈 | 低 | Hermes 通过 shell/MCP 调用外部工具，不要求项目本身用 Python |
+| 133k stars 项目可能快速演进，API 不稳定 | 中 | 锁版本（v0.12.0），skill 用标准格式降低耦合 |
+| 自托管运维负担 | 低 | Docker 部署 + Modal serverless 休眠，基本零运维 |
+
+---
+
+## 6. 结论
+
+**Hermes Agent 对 Mycelium Protocol 生态有显著价值**，核心在三个方向：
+
+1. **自动化运营**：sync-progress / sync-context-reverse 等 skill 的定时自动执行，解决"忘记跑/漏掉 build+deploy"的反复出现的人为失误
+2. **多平台触达**：进度报告、接口变更、合规状态通过 Telegram/Discord 主动推送给团队，比静态页面更有效
+3. **Agent24/iDoris 加速**：Hermes 的 skill 自创建 + 持久记忆 + 多平台网关 覆盖了 Agent24 70% 的规划功能，可大幅缩短开发周期
+
+**建议立即启动短期试点**（1-2 周），用 sync-progress 自动化作为切入点验证可行性。
+
+---
+
+## Sources
+
+- [NousResearch/hermes-agent — GitHub](https://github.com/NousResearch/hermes-agent)
+- [Hermes Agent 官方文档](https://hermes-agent.nousresearch.com/docs/)
+- [Architecture — Developer Guide](https://hermes-agent.nousresearch.com/docs/developer-guide/architecture)
+- [Features Overview](https://hermes-agent.nousresearch.com/docs/user-guide/features/overview)
+- [Skills Hub](https://hermes-agent.nousresearch.com/docs/skills/)
+- [Hermes Agent Self-Evolution](https://github.com/NousResearch/hermes-agent-self-evolution)
+- [Hermes Agent + GoldRush 集成](https://goldrush.dev/agents/hermes-agent/)

--- a/research/localai/README.md
+++ b/research/localai/README.md
@@ -1,0 +1,290 @@
+# M1 Max 64GB 本地 AI 内存预算与场景切换方案
+
+> 维护者：jason | 创建日期：2026-05-05
+> 硬件：Apple M1 Max · 64GB 统一内存 · 32 核 GPU
+> 在线表格：[Google Sheets](https://docs.google.com/spreadsheets/d/1W6PKAqBc27Z46zzz5Ln8UmMK2_9OOP2MKvaEX81_S9U/edit)
+> 参考：[M1 Max 64GB 本地 AI 模型选择指南](https://blog.mushroom.cv/blog/m1-max-64gb-local-ai-model-selection-memory-guide/)
+
+---
+
+## 1. 内存预算总览
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    64GB 统一内存                          │
+├──────────────┬──────────────────────────────────────────┤
+│  系统 + 软件  │          AI 可用空间                      │
+│    16GB      │           48GB                           │
+│  (常驻固定)   │  ┌──────────┬──────────┬──────────┐     │
+│              │  │ 常驻服务  │ 主力模型  │ 场景工具  │     │
+│              │  │  3-4GB   │ 32-41GB  │ 按需加载  │     │
+│              │  └──────────┴──────────┴──────────┘     │
+└──────────────┴──────────────────────────────────────────┘
+```
+
+| 层 | 预算 | 内容 | 管理方式 |
+|:---|:---:|:---|:---|
+| **系统层** | 16GB | macOS + 浏览器 + 编辑器 + 终端 | 固定占用 |
+| **常驻服务层** | 3-4GB | Ollama(BGE 嵌入) + oMLX 守护进程 | 开机自启 |
+| **主力模型层** | 32-41GB | Qwen3 系列 LLM（同一时间仅一个） | oMLX 自动切换 |
+| **场景工具层** | 可变 | 图/音/视频生成、OCR 等 | 独立脚本，用完即卸 |
+
+---
+
+## 2. 运行时架构
+
+```
+oMLX (localhost:11434, OpenAI 兼容)
+├── Qwen3-30B-A3B    32GB  ← 日常默认（MoE，激活仅 3.3B）
+├── Qwen3.6-27B      35GB  ← 代码开发
+└── Qwen3-32B        41GB  ← 深度推理/高质量创作
+    ⚙️ 同一时间仅加载一个，切换自动卸载，闲置 10min 自动释放
+
+apfel (独立进程)
+└── Apple Intelligence 3B  ~2GB  ← 轻量预处理
+
+Ollama (独立进程)
+├── bge-m3           ~1.5GB ← 嵌入向量/RAG
+└── 小模型 (7-8B)    ~5GB   ← 辅助工具调用
+
+独立脚本 (用完即卸)
+├── ComfyUI + FLUX/SDXL     ← 图片生成
+├── CosyVoice2 / ChatTTS    ← 语音合成
+├── Wan2.1-1.3B              ← 短视频生成
+└── GOT-OCR2 / Marker        ← 文档 OCR
+```
+
+---
+
+## 3. 全模型清单
+
+### 3.1 主力 LLM（oMLX 管理，互斥加载）
+
+| 模型 | 参数量 | 量化 | 内存 | 类型 | 场景 | 驻留策略 |
+|:---|:---:|:---:|:---:|:---|:---|:---|
+| **Qwen3-30B-A3B** | 30.5B (激活 3.3B) | 8bit | 32GB | MoE 稀疏 | 日常全能·128K 上下文 | **默认常驻** |
+| **Qwen3.6-27B** | 27B | 8bit | 35GB | Dense | 代码开发·结构化输出 | 场景切换 |
+| **Qwen3-32B** | 32.8B | 8bit | 41GB | Dense 旗舰 | 深度推理·高质量创作 | 场景切换 |
+
+### 3.2 轻量预处理（apfel，独立进程）
+
+| 模型 | 参数量 | 内存 | 场景 | 驻留策略 |
+|:---|:---:|:---:|:---|:---|
+| **Apple Intelligence 3B** | 3B | ~2GB | 笔记摘要·关键词·CSV 解析·格式预处理 | 按需启动 |
+
+### 3.3 嵌入与工具模型（Ollama）
+
+| 模型 | 参数量 | 内存 | 场景 | 驻留策略 |
+|:---|:---:|:---:|:---|:---|
+| **bge-m3** | 568M | ~1.5GB | 文档嵌入·RAG 检索 | 常驻 |
+| **qwen3:8b** | 8B | ~5GB | 轻量工具调用·函数执行 | 按需 |
+
+### 3.4 图片生成（mflux / ComfyUI / Draw Things）
+
+| 模型 | 参数量 | 内存 | 运行时 | 场景 | 驻留策略 |
+|:---|:---:|:---:|:---|:---|:---|
+| **FLUX.1-schnell** | 12B | ~16GB (8bit) | mflux (MLX 原生) | 快速文生图（~20s/张） | 用完即卸 |
+| **FLUX.1-dev** | 12B | ~16GB (8bit) | mflux (MLX 原生) | 高质量文生图（25+ steps） | 用完即卸 |
+| **SDXL** | 3.5B | ~6-8GB | Draw Things / ComfyUI (MPS) | 轻量文生图·LoRA·ControlNet | 用完即卸 |
+| **SD 1.5** | 0.9B | ~4GB | MochiDiffusion (CoreML) | 最快出图·成熟生态 | 用完即卸 |
+
+### 3.5 语音合成 TTS（PyTorch MPS）
+
+| 模型 | 参数量 | 内存 | 场景 | 驻留策略 |
+|:---|:---:|:---:|:---|:---|
+| **F5-TTS** | 155M | ~2-3GB | 快速 TTS·RTF 0.15·最轻量 | 用完即卸 |
+| **CosyVoice2-0.5B** | 500M | ~3GB | 中文语音克隆·多语种·口播音频 | 用完即卸 |
+| **ChatTTS** | ~300M | ~4GB | 对话式中文/英文 TTS | 用完即卸 |
+| **Bark (small)** | ~300M | ~2.3GB | 多语种 + 音效·表情丰富 | 用完即卸 |
+
+### 3.6 视频生成（MLX 原生）
+
+| 模型 | 参数量 | 内存 | 运行时 | 场景 | 驻留策略 |
+|:---|:---:|:---:|:---|:---|:---|
+| **LTX-2.3 Distilled Q4** | ~2B | ~19GB | ltx-video-mac (MLX) | 短视频生成·64GB 最佳选择 | 用完即卸 |
+| **LTX-2 Unified** | ~2B | ~42GB | ltx-video-mac (MLX) | 高质量视频·占满预算 | 用完即卸 |
+| **Wan2.1-T2V-1.3B** | 1.3B | ~24GB | Wan2.2-mlx (MLX) | 文生视频·较慢 | 用完即卸 |
+
+> **重要**：视频生成必须独占运行，启动前卸载 oMLX 中的 LLM。14B+ 模型不适合 64GB。
+
+### 3.7 文档处理（独立脚本）
+
+| 模型 | 参数量 | 内存 | 运行时 | 场景 | 驻留策略 |
+|:---|:---:|:---:|:---|:---|:---|
+| **GOT-OCR2** | 580M | ~3-4GB | transformers (MPS) | 图片/PDF 端到端 OCR | 用完即卸 |
+| **Marker (Surya)** | ~150M | ~2-3GB | pip install marker-pdf | PDF → Markdown 转换 | 用完即卸 |
+| **Surya** | ~150M | ~2-3GB | pip install surya-ocr | 90+ 语种 OCR·表格识别 | 用完即卸 |
+
+### 3.8 翻译
+
+Qwen3 系列原生支持 100+ 语言，日常翻译无需额外模型。批量/专业翻译可用专用模型。
+
+| 模型 | 参数量 | 内存 | 场景 | 驻留策略 |
+|:---|:---:|:---:|:---|:---|
+| *(复用 Qwen3-30B-A3B)* | — | 0 额外 | 日常中英/日/韩翻译 | 跟随主力 |
+| **NLLB-200-distilled-600M** | 600M | ~3GB | 200 语种批量翻译 | 用完即卸 |
+| **NLLB-200-1.3B** | 1.3B | ~5-6GB | 高质量多语种翻译 | 用完即卸 |
+| **Helsinki-NLP OPUS-MT** | 50-80M/对 | <1GB | 特定语对·极速翻译 | 用完即卸 |
+
+---
+
+## 4. 场景切换方案
+
+### 场景 A：日常（信息收集·文档·博客·社媒发布）
+
+```
+总占用 ≈ 16 + 32 + 1.5 = 49.5GB    余量 14.5GB ✅
+┌──────────────────────────────────────────┐
+│ oMLX: Qwen3-30B-A3B (32GB) ← 默认常驻   │
+│ Ollama: bge-m3 (1.5GB)     ← 常驻       │
+│ apfel: Apple 3B (按需)      ← 预处理     │
+└──────────────────────────────────────────┘
+```
+
+**能力覆盖**：
+- 信息收集 + 摘要过滤 → Qwen3-30B-A3B（128K 上下文）
+- 文件分析 + 格式转换 → Qwen3-30B-A3B + Apple 3B 预处理
+- 博客撰写 + 社媒文案 → Qwen3-30B-A3B
+- RAG 检索 → bge-m3
+
+### 场景 B：创作（全媒体发布 + 短视频制作）
+
+**B-1: 文案 + 口播阶段**（LLM 主导）
+```
+总占用 ≈ 16 + 32 + 3 = 51GB    余量 13GB ✅
+┌──────────────────────────────────────────┐
+│ oMLX: Qwen3-30B-A3B (32GB)  ← 脚本创作  │
+│ 脚本: CosyVoice2 (3GB)      ← 口播生成  │
+└──────────────────────────────────────────┘
+```
+
+**B-2: 图片素材阶段**（图片生成主导）
+```
+方案 1 ≈ 16 + 6 = 22GB     余量 42GB ✅ (SDXL 轻量)
+方案 2 ≈ 16 + 16 = 32GB    余量 32GB ✅ (FLUX 高质量)
+┌──────────────────────────────────────────┐
+│ Draw Things: SDXL (6-8GB)  ← 快速批量   │
+│ 或 mflux: FLUX-schnell (16GB) ← 高质量  │
+│ oMLX: 建议先卸载 LLM 腾出空间           │
+│ （SDXL 可与 30B LLM 共存，FLUX 不建议） │
+└──────────────────────────────────────────┘
+```
+
+**B-3: 视频合成阶段**（视频生成 + 剪辑）⚠️ 必须独占
+```
+方案 1 ≈ 16 + 19 = 35GB    余量 29GB ✅ (LTX-2.3 最佳)
+方案 2 ≈ 16 + 24 = 40GB    余量 24GB ✅ (Wan2.1)
+┌──────────────────────────────────────────┐
+│ ltx-video-mac: LTX-2.3 Q4 (19GB) ← 推荐│
+│ 或 Wan2.2-mlx: Wan2.1-1.3B (24GB)      │
+│ Final Cut / DaVinci         ← 剪辑合成  │
+│ oMLX: 必须卸载！视频生成独占 AI 内存     │
+└──────────────────────────────────────────┘
+```
+
+### 场景 C：代码开发
+
+```
+总占用 ≈ 16 + 35 + 1.5 = 52.5GB    余量 11.5GB ✅
+┌──────────────────────────────────────────┐
+│ oMLX: Qwen3.6-27B (35GB)    ← 代码生成  │
+│ Ollama: bge-m3 (1.5GB)      ← 代码检索  │
+└──────────────────────────────────────────┘
+```
+
+### 场景 D：深度推理 / 长文创作
+
+```
+总占用 ≈ 16 + 41 = 57GB    余量 7GB ⚠️ (刚好够)
+┌──────────────────────────────────────────┐
+│ oMLX: Qwen3-32B (41GB)      ← 深度推理  │
+│ 其他服务建议全部卸载                      │
+└──────────────────────────────────────────┘
+```
+
+### 场景 E：特定任务
+
+| 子场景 | 配置 | 总占用 | 余量 |
+|:---|:---|:---:|:---:|
+| **翻译** | Qwen3-30B-A3B (32GB) | ~48GB | 16GB |
+| **PDF→MD 转换** | Marker (2-3GB) + Qwen3-30B-A3B (32GB) | ~51GB | 13GB |
+| **OCR 识别** | GOT-OCR2 (3-4GB) + Qwen3-30B-A3B (32GB) | ~52GB | 12GB |
+| **游戏原型** | Qwen3.6-27B (35GB) + Unity/Godot | ~55GB | 9GB |
+
+---
+
+## 5. 切换操作速查
+
+| 操作 | 命令 / 方法 |
+|:---|:---|
+| **查看当前加载模型** | oMLX 菜单栏查看 |
+| **切换主力 LLM** | oMLX 界面选择模型（自动卸载前序） |
+| **手动释放全部** | oMLX 菜单栏 Stop 按钮 |
+| **启动图片生成** | `python -m comfyui` 或 ComfyUI 桌面版 |
+| **启动 TTS** | `python run_cosyvoice.py` |
+| **启动视频生成** | `python run_wan21.py` |
+| **释放非 oMLX 模型** | 终止对应 Python 进程 |
+
+---
+
+## 6. 内存安全规则
+
+1. **一个大模型原则**：oMLX 同一时间只加载一个 27B+ 模型
+2. **创作前先卸载**：启动 ComfyUI/视频生成前，先 Stop oMLX 中的 LLM
+3. **闲置自动释放**：oMLX 10 分钟无请求自动卸载
+4. **视频编辑排他**：Final Cut / DaVinci Resolve 工作时，不跑 AI 大模型
+5. **浏览器控制**：限制 Chrome/Arc 标签数 ≤ 20，避免内存膨胀
+6. **Swap 告警**：如果 Activity Monitor 显示内存压力为黄色/红色，立即卸载多余模型
+
+---
+
+## 7. 模型获取
+
+```bash
+# ═══ 主力 LLM（oMLX 内置下载）═══
+# 在 oMLX 界面搜索 Qwen3-30B-A3B / Qwen3.6-27B / Qwen3-32B
+
+# ═══ 嵌入模型 ═══
+ollama pull bge-m3
+
+# ═══ 图片生成 ═══
+# mflux: MLX 原生 FLUX 推理（推荐）
+pip install mflux
+# 模型首次运行自动下载
+
+# Draw Things: macOS 原生 SDXL 应用（App Store 免费）
+# 或 ComfyUI + MPS 后端
+
+# ═══ TTS ═══
+pip install f5-tts          # 最轻量
+pip install cosyvoice       # 中文语音克隆
+pip install ChatTTS         # 对话式
+
+# ═══ 视频生成 ═══
+# LTX-2.3: MLX 原生，64GB 最佳选择
+# 下载 ltx-video-mac: https://github.com/james-see/ltx-video-mac
+
+# Wan2.1 MLX 版
+pip install wan2-mlx
+
+# ═══ 文档处理 ═══
+pip install marker-pdf      # PDF → Markdown
+pip install surya-ocr       # 多语种 OCR
+
+# ═══ 翻译 ═══
+pip install transformers    # NLLB / OPUS-MT
+```
+
+## 8. 参考资源
+
+| 工具 | 链接 |
+|:---|:---|
+| oMLX | oMLX 官方 (Apple Silicon MLX 优化推理) |
+| mflux | [github.com/filipstrand/mflux](https://github.com/filipstrand/mflux) |
+| ltx-video-mac | [github.com/james-see/ltx-video-mac](https://github.com/james-see/ltx-video-mac) |
+| Wan2.2-mlx | [github.com/osama-ata/Wan2.2-mlx](https://github.com/osama-ata/Wan2.2-mlx) |
+| F5-TTS | [github.com/SWivid/F5-TTS](https://github.com/SWivid/F5-TTS) |
+| CosyVoice | [github.com/FunAudioLLM/CosyVoice](https://github.com/FunAudioLLM/CosyVoice) |
+| GOT-OCR2 | [huggingface.co/stepfun-ai/GOT-OCR2_0](https://huggingface.co/stepfun-ai/GOT-OCR2_0) |
+| Marker | [pypi.org/project/marker-pdf](https://pypi.org/project/marker-pdf/) |
+| Draw Things | macOS App Store 免费 |

--- a/research/localai/memory-budget.tsv
+++ b/research/localai/memory-budget.tsv
@@ -1,0 +1,42 @@
+类别	模型名称	参数量	内存占用	量化/格式	运行时	驻留策略	适用场景	备注
+═══ 主力 LLM（oMLX 管理，互斥加载）═══
+LLM	Qwen3-30B-A3B	30.5B (激活3.3B)	32GB	8bit MLX	oMLX	默认常驻	日常全能·128K上下文·信息收集·文案·翻译	MoE 稀疏架构，90%日常首选
+LLM	Qwen3.6-27B	27B	35GB	8bit MLX	oMLX	场景切换	代码开发·结构化输出	Dense 架构
+LLM	Qwen3-32B	32.8B	41GB	8bit MLX	oMLX	场景切换	深度推理·高质量长文创作	Dense 旗舰，余量仅7GB
+═══ 常驻服务 ═══
+嵌入/RAG	bge-m3	568M	1.5GB	—	Ollama	常驻	文档嵌入·RAG检索	开机自启
+预处理	Apple Intelligence 3B	3B	2GB	—	apfel	按需启动	笔记摘要·关键词·CSV解析·格式预处理	Neural Engine加速
+═══ 图片生成（独立脚本，用完即卸）═══
+图片生成	FLUX.1-schnell	12B	16GB	8bit MLX	mflux	用完即卸	快速文生图（~20s/张）	MLX原生，推荐
+图片生成	FLUX.1-dev	12B	16GB	8bit MLX	mflux	用完即卸	高质量文生图（25+steps）	MLX原生
+图片生成	SDXL	3.5B	6-8GB	FP16	Draw Things / ComfyUI	用完即卸	轻量文生图·LoRA·ControlNet	可与30B LLM共存
+图片生成	SD 1.5	0.9B	4GB	CoreML	MochiDiffusion	用完即卸	最快出图·成熟生态
+═══ 语音合成 TTS（独立脚本，用完即卸）═══
+TTS	F5-TTS	155M	2-3GB	—	PyTorch MPS	用完即卸	快速TTS·RTF 0.15	最轻量选择
+TTS	CosyVoice2-0.5B	500M	3GB	—	PyTorch MPS	用完即卸	中文语音克隆·多语种·口播	推荐中文
+TTS	ChatTTS	300M	4GB	—	PyTorch MPS	用完即卸	对话式中文/英文TTS
+TTS	Bark (small)	300M	2.3GB	—	transformers MPS	用完即卸	多语种+音效·表情丰富
+═══ 视频生成（独立脚本，必须独占）═══
+视频生成	LTX-2.3 Distilled Q4	2B	19GB	Q4 MLX	ltx-video-mac	用完即卸	短视频生成·64GB最佳选择	推荐，必须先卸载LLM
+视频生成	LTX-2 Unified	2B	42GB	MLX	ltx-video-mac	用完即卸	高质量视频·占满预算	仅视频独占时用
+视频生成	Wan2.1-T2V-1.3B	1.3B	24GB	MLX	Wan2.2-mlx	用完即卸	文生视频·较慢	备选
+═══ 文档处理（独立脚本，用完即卸）═══
+OCR	GOT-OCR2	580M	3-4GB	—	transformers MPS	用完即卸	端到端OCR·图片/PDF
+PDF转换	Marker (Surya)	150M	2-3GB	—	pip install marker-pdf	用完即卸	PDF→Markdown
+OCR	Surya	150M	2-3GB	—	pip install surya-ocr	用完即卸	90+语种OCR·表格识别
+═══ 翻译（复用LLM或独立）═══
+翻译	(复用 Qwen3-30B-A3B)	—	0 额外	—	oMLX	跟随主力	日常中英/日/韩翻译	原生100+语种
+翻译	NLLB-200-distilled-600M	600M	3GB	FP32	transformers MPS	用完即卸	200语种批量翻译
+翻译	NLLB-200-1.3B	1.3B	5-6GB	FP32	transformers MPS	用完即卸	高质量多语种翻译
+翻译	Helsinki-NLP OPUS-MT	50-80M/对	<1GB	—	transformers	用完即卸	特定语对·极速
+═══ 场景内存预算 ═══
+场景	配置	总占用	余量	适用
+场景A: 日常	oMLX(30B-A3B) + Ollama(BGE)	49.5GB	14.5GB	信息收集·文档·博客·社媒
+场景B-1: 文案+口播	oMLX(30B-A3B) + CosyVoice2	51GB	13GB	脚本创作+口播生成
+场景B-2: 图片素材	SDXL(6-8GB) 独立	22-24GB	40-42GB	批量出图（卸载LLM）
+场景B-2: 图片素材(高质量)	mflux FLUX-schnell(16GB)	32GB	32GB	高质量出图（卸载LLM）
+场景B-3: 视频合成	LTX-2.3 Q4(19GB) 独占	35GB	29GB	AI短片+Final Cut剪辑
+场景C: 代码开发	oMLX(Qwen3.6-27B) + Ollama(BGE)	52.5GB	11.5GB	代码生成+代码检索
+场景D: 深度推理	oMLX(Qwen3-32B) 独占	57GB	7GB	深度推理·长文创作
+场景E: 翻译	oMLX(30B-A3B)	48GB	16GB	复用日常LLM
+场景E: OCR	GOT-OCR2 + oMLX(30B-A3B)	52GB	12GB	OCR+LLM后处理


### PR DESCRIPTION
## Summary

2 篇文档（2026-05 已 push 但未开 PR）：

1. **Hermes Agent 分析** — NousResearch/hermes-agent (v0.12.0, 133k stars, MIT) 对 Brood 生态的适配性研究；推荐先用 sync-progress 作为试点入口
2. **research/localai/** — M1 Max 64GB 本地 AI 内存预算 + 场景切换方案：覆盖 LLM (Qwen3/oMLX), 图像 (FLUX/SDXL/mflux), TTS (CosyVoice2/F5-TTS), 视频 (LTX-2.3), OCR (GOT-OCR2/Marker), 翻译 (NLLB)；含 Google Sheets TSV 导出

## 性质
- 100% 文档
- 与 hyphae-training 研究有协同价值（Hermes 可作为 Agent24 替代候选）

## Test plan
- [x] 内容是 1.5 月前的研究，仍然有效